### PR TITLE
Fix the --logging-program argument

### DIFF
--- a/delfick_project/app.py
+++ b/delfick_project/app.py
@@ -558,7 +558,7 @@ class CliParser(object):
 
         logging.add_argument("--debug", help="Debug logs", action="store_true")
 
-        logging.add_argument(
+        parser.add_argument(
             "--logging-program", help="The program name to use when not logging to the console"
         )
 


### PR DESCRIPTION
By making it independent of the logging verbosity options. Fixes #1.

Signed-off-by: Avi Miller <me@dje.li>